### PR TITLE
syntax errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ mysql-connector-python==8.0.24
 pipreqs==0.4.10
 psycopg2-binary==2.9.1
 requests==2.26.0
-urllib3==1.26.6v
+urllib3==1.26.6
 yarg==0.1.9
 nltk>=3.6.5
 usaddress>=0.5.10
 sqlalchemy>=1.4.2
-scipy=>1.7.1
+scipy>=1.7.1


### PR DESCRIPTION
python 3.8.11 did not like the lines when I did the pip3 install. My modifications allowed the install.